### PR TITLE
Added optional params: limit and offset to index

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,2 +1,2 @@
 export function setCredentials(id: string, key: string): void;
-export function search(query: string): Promise<any>;
+export function search(query: string, offset?: number, limit?: number): Promise<any>;


### PR DESCRIPTION
### Why
We can't set limits or offset within the search function for TS. This change adds these optional params. - See issue #16 

### What
Added optional params to the definition.